### PR TITLE
feat: implement granular price filtering, float bazaar prices, and gzip support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,13 +64,13 @@ hyper = { version = "0.14", features = [
     "nightly",
 ] }
 # Misc
-flate2 = "1.0"
+flate2 = "1.1"
 once_cell = { version = "1.18", features = ["parking_lot"] }
 anyhow = { version = "1.0", features = ["backtrace"] }
 mimalloc = { version = "0.1", default-features = false }
 parking_lot = { version = "0.12", features = ["serde", "arc_lock", "nightly"] }
 quote = "1.0"
-reqwest = { version = "0.11.20", default-features = false, features = [
+reqwest = { version = "0.11", default-features = false, features = [
     "http3",
 ] }
 

--- a/README.md
+++ b/README.md
@@ -61,13 +61,20 @@ print(json["ENCHANTMENT_ULTIMATE_SWARM_2"])
 
 ### Api endpoints
 
-#### `/lowestbins` | `/lowestbins.json` | `/auctions/lowestbins`
+#### `/lowestbins` | `/lowestbins.json`
 
-> Returns a json object with all lowestbins
+> Returns a JSON object with lowest bins and bazaar prices. Supports `?type` and `?price` filters.
 
 #### `/averages/{1-7}day`
 
 > Returns the historical price average for the specified number of days (e.g., `/averages/7day`). Requires `ENABLE_HISTORY=1`.
+
+> **Note on Compression:** All endpoints support robust Gzip compression to save bandwidth. Just append `.gz` to the path (e.g., `/lowestbins.json.gz`, `/averages/1day.json.gz`).
+
+> **Query Parameters:**
+> Most data endpoints support the following filters:
+> - `?type=all|auction|bazaar` (Default: `all`) - Filters items by their market source.
+> - `?price=historical|available` (Default: `historical`) - Filters auction items by their state (`available` means currently active on the Auction House).
 
 #### Special handling
 
@@ -134,6 +141,8 @@ ENABLE_HISTORY # set to 1 to enable historical price tracking (default: 0)
 - metrics endpoint `/metrics`
 - rust
 - price history
+- granular filtering (`?type` & `?price`)
+- gzip compression
 
 ## Todo
 

--- a/src/fetch/bazaar.rs
+++ b/src/fetch/bazaar.rs
@@ -15,23 +15,55 @@ pub struct BazaarResponse {
 
 #[derive(Deserialize, Debug)]
 pub struct Product {
-    #[serde(rename = "quick_status")]
-    pub quick_status: QuickStatus,
+    #[serde(rename = "buy_summary")]
+    pub buy_summary: Vec<SummaryEntry>,
+}
+
+impl Product {
+    #[inline]
+    pub fn lowest_buy_price(&self) -> f64 {
+        match self.buy_summary.as_slice() {
+            [] => 0.0,
+            [single] => {
+                let p = single.price_per_unit;
+                if p.is_finite() {
+                    p
+                } else {
+                    0.0
+                }
+            }
+            entries => entries
+                .iter()
+                .map(|s| s.price_per_unit)
+                .filter(|p| p.is_finite())
+                .fold(f64::MAX, f64::min),
+        }
+    }
 }
 
 #[derive(Deserialize, Debug)]
-pub struct QuickStatus {
-    #[serde(rename = "buyPrice")]
-    pub buy_price: f64,
+pub struct SummaryEntry {
+    #[serde(rename = "pricePerUnit")]
+    pub price_per_unit: f64,
 }
+
 pub async fn get_bazaar() -> Result<BazaarResponse> {
     get_path("bazaar").await
 }
 
-pub async fn get_bazaar_products(auctions: &DashMap<String, u64>) -> Result<()> {
-    let bz = get_bazaar().await?;
+pub async fn get_bazaar_products(bazaar_map: &DashMap<String, f64>) -> Result<()> {
+    let bz = get_path::<BazaarResponse>("bazaar").await?;
     let prods = bz.products;
+
     for (mut key, val) in prods.into_iter() {
+        let price = val.lowest_buy_price();
+        // Skip items with no buy orders or invalid prices.
+        // This also protects history.rs from tanking averages with 0.0 values,
+        // as the item will be absent from the snapshot and won't increment the counter.
+        if price <= 0.0 {
+            continue;
+        }
+
         if key.starts_with("ENCHANTMENT") {
             let mut split = key.split('_');
             split.next();
@@ -42,7 +74,8 @@ pub async fn get_bazaar_products(auctions: &DashMap<String, u64>) -> Result<()> 
 
             key = format!("ENCHANTED_BOOK-{}-{}", name_parts.join("_"), level[0]);
         }
-        auctions.insert(key, val.quick_status.buy_price.round() as u64);
+
+        bazaar_map.insert(key, price);
     }
     Ok(())
 }

--- a/src/fetch/bazaar.rs
+++ b/src/fetch/bazaar.rs
@@ -36,7 +36,8 @@ impl Product {
                 .iter()
                 .map(|s| s.price_per_unit)
                 .filter(|p| p.is_finite())
-                .fold(f64::MAX, f64::min),
+                .reduce(f64::min)
+                .unwrap_or(0.0),
         }
     }
 }

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -8,6 +8,7 @@ use crate::{
     webhook::*,
     AUCTIONS, CONFIG,
 };
+use std::collections::BTreeMap;
 
 use dashmap::DashMap;
 use futures_util::{stream::FuturesUnordered, FutureExt, StreamExt};
@@ -19,10 +20,11 @@ pub mod bazaar;
 pub mod util;
 
 pub async fn fetch_auctions() -> Result<()> {
-    let start = std::time::Instant::now();
+    let start = Instant::now();
     let hs = get_auctions_page(0).await?;
 
     let auctions: DashMap<String, u64> = DashMap::new();
+    let bazaar: DashMap<String, f64> = DashMap::new();
     parse_auctions(hs.auctions, &auctions)?;
 
     let futures = FuturesUnordered::new();
@@ -30,18 +32,24 @@ pub async fn fetch_auctions() -> Result<()> {
     for url in 1..hs.total_pages {
         futures.push(get_auctions(url, &auctions).boxed());
     }
-    futures.push(get_bazaar_products(&auctions).boxed());
+    futures.push(get_bazaar_products(&bazaar).boxed());
 
     let _: Vec<_> = futures.collect().await;
-    let fetched = auctions.len();
+    let fetched = auctions.len() + bazaar.len();
     let fetch_time = n.elapsed();
 
-    let mut new_auctions = DashMap::new();
-    new_auctions.extend(auctions.clone());
-    drop(auctions);
+    let mut new_auctions = BTreeMap::new();
+    for kv in auctions.into_iter() {
+        new_auctions.insert(kv.0, kv.1);
+    }
     new_auctions.extend(CONFIG.overwrites.clone());
 
-    tracing::debug!("Fetched {} auctions in {:?}", fetched, fetch_time);
+    let mut new_bazaar = BTreeMap::new();
+    for kv in bazaar.into_iter() {
+        new_bazaar.insert(kv.0, kv.1);
+    }
+
+    tracing::debug!("Fetched {} items in {:?}", fetched, fetch_time);
     // It only sends if the WEBHOOK_URL env var is set
     send_embed(Message::new(
         "Auctions updated".to_owned(),
@@ -59,11 +67,23 @@ pub async fn fetch_auctions() -> Result<()> {
 
     let snapshot = {
         let mut auc = AUCTIONS.lock();
-        auc.extend(new_auctions);
+        auc.available_auctions = new_auctions.clone();
+        auc.historical_auctions.extend(new_auctions);
+        auc.bazaar = new_bazaar;
+
+        let mut combined: BTreeMap<String, f64> = BTreeMap::new();
+        for (k, v) in &auc.available_auctions {
+            combined.insert(k.clone(), *v as f64);
+        }
+        for (k, v) in &auc.bazaar {
+            combined.insert(k.clone(), *v);
+        }
+
         set_last_updates();
-        auc.clone()
+        combined
     };
     crate::history::update_history(snapshot);
+    crate::server::clear_response_cache();
 
     Ok(())
 }

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -67,20 +67,16 @@ pub async fn fetch_auctions() -> Result<()> {
 
     let snapshot = {
         let mut auc = AUCTIONS.lock();
+        for k in new_bazaar.keys() {
+            auc.historical_auctions.remove(k);
+        }
         auc.available_auctions = new_auctions.clone();
         auc.historical_auctions.extend(new_auctions);
         auc.bazaar = new_bazaar;
 
-        let mut combined: BTreeMap<String, f64> = BTreeMap::new();
-        for (k, v) in &auc.available_auctions {
-            combined.insert(k.clone(), *v as f64);
-        }
-        for (k, v) in &auc.bazaar {
-            combined.insert(k.clone(), *v);
-        }
-
         set_last_updates();
-        combined
+
+        auc.build_combined_map(crate::FilterType::All, crate::FilterPrice::Available)
     };
     crate::history::update_history(snapshot);
     crate::server::clear_response_cache();

--- a/src/history.rs
+++ b/src/history.rs
@@ -9,7 +9,7 @@ use parking_lot::{Mutex, RwLock};
 use serde::{ser::SerializeMap, Deserialize, Serialize};
 use tokio::task;
 
-const DAY_SLOTS: usize = 7;
+pub(crate) const DAY_SLOTS: usize = 7;
 const PERSIST_PATH: &str = "history.json";
 
 fn now_secs() -> u64 {
@@ -31,9 +31,9 @@ fn day_start_of(ts: u64) -> u64 {
 struct PersistData {
     day_acc_start: u64,
     // (item_id -> (sum, count)) for the partial current day
-    day_acc: HashMap<String, (u64, u32)>,
+    day_acc: HashMap<String, (f64, u32)>,
     // (day_start_ts, item_id -> (sum, count)) for completed days
-    day_slots: Vec<(u64, HashMap<String, (u64, u32)>)>,
+    day_slots: Vec<(u64, HashMap<String, (f64, u32)>)>,
 }
 
 struct PriceHistory {
@@ -42,12 +42,12 @@ struct PriceHistory {
 
     // Running accumulator for the current calendar day
     day_acc_start: u64,
-    day_acc_sum: Vec<u64>,
+    day_acc_sum: Vec<f64>,
     day_acc_count: Vec<u32>,
 
     // Up to 7 completed calendar days
     // Each entry: (day_start_ts, price_sum_per_item, snapshot_count_per_item)
-    day_slots: VecDeque<(u64, Vec<u64>, Vec<u32>)>,
+    day_slots: VecDeque<(u64, Vec<f64>, Vec<u32>)>,
 }
 
 impl PriceHistory {
@@ -93,7 +93,7 @@ impl PriceHistory {
 
         let n = items.len();
 
-        let mut day_acc_sum = vec![0u64; n];
+        let mut day_acc_sum = vec![0.0; n];
         let mut day_acc_count = vec![0u32; n];
         for (key, (sum, count)) in &p.day_acc {
             if let Some(&idx) = item_index.get(key) {
@@ -106,7 +106,7 @@ impl PriceHistory {
             .day_slots
             .into_iter()
             .map(|(ts, map)| {
-                let mut sum = vec![0u64; n];
+                let mut sum = vec![0.0; n];
                 let mut count = vec![0u32; n];
                 for (key, (s, c)) in map {
                     if let Some(&idx) = item_index.get(&key) {
@@ -143,10 +143,10 @@ impl PriceHistory {
         let idx = self.items.len();
         self.item_index.insert(key.to_owned(), idx);
         self.items.push(key.to_owned());
-        self.day_acc_sum.push(0);
+        self.day_acc_sum.push(0.0);
         self.day_acc_count.push(0);
         for (_, sum, count) in &mut self.day_slots {
-            sum.push(0);
+            sum.push(0.0);
             count.push(0);
         }
         idx
@@ -154,7 +154,7 @@ impl PriceHistory {
 
     pub fn push_snapshot<I>(&mut self, prices: I)
     where
-        I: IntoIterator<Item = (String, u64)>,
+        I: IntoIterator<Item = (String, f64)>,
     {
         let ts = now_secs();
         let current_day = day_start_of(ts);
@@ -162,7 +162,7 @@ impl PriceHistory {
         // Day rollover: finalize the current accumulator into a completed day slot
         if current_day != self.day_acc_start {
             let n = self.items.len();
-            let sum = std::mem::replace(&mut self.day_acc_sum, vec![0u64; n]);
+            let sum = std::mem::replace(&mut self.day_acc_sum, vec![0.0; n]);
             let count = std::mem::replace(&mut self.day_acc_count, vec![0u32; n]);
             self.day_slots.push_back((self.day_acc_start, sum, count));
             // Maintain sliding window by removing the oldest day slot
@@ -174,6 +174,8 @@ impl PriceHistory {
 
         for (key, price) in prices {
             let idx = self.ensure_item(&key);
+            // Only items present in the snapshot contribute to the daily average.
+            // Absent items (e.g., price <= 0.0 in fetch) are ignored, maintaining average integrity.
             self.day_acc_sum[idx] += price;
             self.day_acc_count[idx] += 1;
         }
@@ -223,7 +225,7 @@ impl<'a> Serialize for AverageView<'a> {
         S: serde::Serializer,
     {
         let n = self.history.items.len();
-        let mut sum = vec![0u64; n];
+        let mut sum = vec![0.0; n];
         let mut count = vec![0u32; n];
 
         // Process current partial day accumulator
@@ -255,7 +257,7 @@ impl<'a> Serialize for AverageView<'a> {
         //  Stream calculations directly to the serializer
         for i in 0..n {
             if count[i] > 0 {
-                map.serialize_entry(&self.history.items[i], &(sum[i] / count[i] as u64))?;
+                map.serialize_entry(&self.history.items[i], &(sum[i] / count[i] as f64))?;
             }
         }
 
@@ -274,7 +276,7 @@ pub fn get_cache(days: u8) -> Option<Bytes> {
 /// Accept any iterator that yields (String, u64) to avoid unnecessary collection conversions.
 pub fn update_history<I>(prices: I)
 where
-    I: IntoIterator<Item = (String, u64)> + Send + 'static,
+    I: IntoIterator<Item = (String, f64)> + Send + 'static,
 {
     if !crate::CONFIG.enable_history {
         return;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,21 @@ impl Conf {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FilterType {
+    All = 0,
+    Auction = 1,
+    Bazaar = 2,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FilterPrice {
+    Historical = 0,
+    Available = 1,
+}
+
 #[derive(Default, Clone)]
 pub struct PriceState {
     pub historical_auctions: BTreeMap<String, u64>,
@@ -88,17 +103,18 @@ pub struct PriceState {
 }
 
 impl PriceState {
-    pub fn get_price(&self, id: &str, q_type: &str, q_price: &str) -> Option<f64> {
-        let show_bz = q_type == "bazaar" || q_type == "all";
-        let show_auc = q_type == "auction" || q_type == "all";
+    pub fn get_price(&self, id: &str, q_type: FilterType, q_price: FilterPrice) -> Option<f64> {
+        let show_bz = q_type == FilterType::Bazaar || q_type == FilterType::All;
+        let show_auc = q_type == FilterType::Auction || q_type == FilterType::All;
 
+        #[allow(clippy::collapsible_if)]
         if show_bz {
             if let Some(&p) = self.bazaar.get(id) {
                 return Some(p);
             }
         }
         if show_auc {
-            let target = if q_price == "available" {
+            let target = if q_price == FilterPrice::Available {
                 &self.available_auctions
             } else {
                 &self.historical_auctions
@@ -111,18 +127,15 @@ impl PriceState {
         None
     }
 
-    pub fn for_each_price<F>(&self, q_type: &str, q_price: &str, mut f: F)
+    pub fn for_each_price<F>(&self, q_type: FilterType, q_price: FilterPrice, mut f: F)
     where
         F: FnMut(&str, f64),
     {
-        let show_bz = q_type == "bazaar" || q_type == "all";
-        let show_auc = q_type == "auction" || q_type == "all";
+        let show_auc = q_type == FilterType::Auction || q_type == FilterType::All;
+        let show_bz = q_type == FilterType::Bazaar || q_type == FilterType::All;
 
-        if show_bz {
-            for (k, &v) in &self.bazaar { f(k, v); }
-        }
         if show_auc {
-            let target = if q_price == "available" {
+            let target = if q_price == FilterPrice::Available {
                 &self.available_auctions
             } else {
                 &self.historical_auctions
@@ -131,9 +144,14 @@ impl PriceState {
                 f(k, v as f64);
             }
         }
+        if show_bz {
+            for (k, &v) in &self.bazaar {
+                f(k, v);
+            }
+        }
     }
 
-    pub fn build_combined_map(&self, q_type: &str, q_price: &str) -> BTreeMap<String, f64> {
+    pub fn build_combined_map(&self, q_type: FilterType, q_price: FilterPrice) -> BTreeMap<String, f64> {
         let mut result = BTreeMap::new();
         self.for_each_price(q_type, q_price, |k, v| {
             result.insert(k.to_string(), v);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,68 @@ impl Conf {
     }
 }
 
+#[derive(Default, Clone)]
+pub struct PriceState {
+    pub historical_auctions: BTreeMap<String, u64>,
+    pub available_auctions: BTreeMap<String, u64>,
+    pub bazaar: BTreeMap<String, f64>,
+}
+
+impl PriceState {
+    pub fn get_price(&self, id: &str, q_type: &str, q_price: &str) -> Option<f64> {
+        let show_bz = q_type == "bazaar" || q_type == "all";
+        let show_auc = q_type == "auction" || q_type == "all";
+
+        if show_bz {
+            if let Some(&p) = self.bazaar.get(id) {
+                return Some(p);
+            }
+        }
+        if show_auc {
+            let target = if q_price == "available" {
+                &self.available_auctions
+            } else {
+                &self.historical_auctions
+            };
+            if let Some(&p) = target.get(id) {
+                return Some(p as f64);
+            }
+        }
+
+        None
+    }
+
+    pub fn for_each_price<F>(&self, q_type: &str, q_price: &str, mut f: F)
+    where
+        F: FnMut(&str, f64),
+    {
+        let show_bz = q_type == "bazaar" || q_type == "all";
+        let show_auc = q_type == "auction" || q_type == "all";
+
+        if show_bz {
+            for (k, &v) in &self.bazaar { f(k, v); }
+        }
+        if show_auc {
+            let target = if q_price == "available" {
+                &self.available_auctions
+            } else {
+                &self.historical_auctions
+            };
+            for (k, &v) in target {
+                f(k, v as f64);
+            }
+        }
+    }
+
+    pub fn build_combined_map(&self, q_type: &str, q_price: &str) -> BTreeMap<String, f64> {
+        let mut result = BTreeMap::new();
+        self.for_each_price(q_type, q_price, |k, v| {
+            result.insert(k.to_string(), v);
+        });
+        result
+    }
+}
+
 // Using lazy it's considered better than lazy_static!
 
 pub static API_URL: Lazy<String> =
@@ -122,10 +184,16 @@ pub fn calc_next_update() -> u64 {
 include!(concat!(env!("OUT_DIR"), "/prices_map.rs"));
 
 // Honestly there should be a better way to do this in a more memory efficient way i think?
-pub static AUCTIONS: Lazy<Mutex<BTreeMap<String, u64>>> = Lazy::new(|| {
-    let mut res: BTreeMap<String, u64> = fs::read("auctions.json")
-        .map(|x| serde_json::from_slice(&x).unwrap())
+pub static AUCTIONS: Lazy<Mutex<PriceState>> = Lazy::new(|| {
+    let historical_auctions: BTreeMap<String, u64> = fs::read("auctions.json")
+        .map(|x| serde_json::from_slice(&x).unwrap_or_default())
         .unwrap_or_default();
-    res.extend(HashMap::from(get_prices_map()));
+
+    let mut res = PriceState {
+        historical_auctions,
+        available_auctions: BTreeMap::new(),
+        bazaar: BTreeMap::new(),
+    };
+    res.historical_auctions.extend(HashMap::from(get_prices_map()));
     Mutex::new(res)
 });

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ fn main() -> Result<()> {
 
     let res = format!(
         "Loaded {} auctions from save\nMade by Tricked-dev - source: {SOURCE}\nOverwrites {:?}, Save To Disk: {}, Update Seconds: {}",
-        AUCTIONS.lock().len(),
+        AUCTIONS.lock().historical_auctions.len(),
         &CONFIG.overwrites,
         &CONFIG.save_to_disk,
         &CONFIG.update_seconds,
@@ -87,7 +87,7 @@ fn main() -> Result<()> {
                 if !AUCTIONS.is_locked() {
                     match fs::write(
                         "auctions.json",
-                        serde_json::to_string_pretty(&*AUCTIONS.lock()).unwrap(),
+                        serde_json::to_string_pretty(&AUCTIONS.lock().historical_auctions).unwrap(),
                     ) {
                         Ok(_) => tracing::debug!("Saved to disk"),
                         Err(_) => tracing::error!(

--- a/src/server.rs
+++ b/src/server.rs
@@ -273,14 +273,13 @@ fn not_found() -> Response<Body> {
 fn parse_query(query: &str) -> (&'static str, &'static str) {
     let (mut t, mut p) = ("all", "historical");
     for param in query.split('&') {
-        let mut parts = param.splitn(2, '=');
-        match (parts.next(), parts.next()) {
-            (Some("type"), Some(v)) => t = match v {
+        match param.split_once('=') {
+            Some(("type", v)) => t = match v {
                 "auction" => "auction",
                 "bazaar" => "bazaar",
                 _ => "all"
             },
-            (Some("price"), Some(v)) => p = match v {
+            Some(("price", v)) => p = match v {
                 "available" => "available",
                 _ => "historical"
             },

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,9 +11,9 @@ use once_cell::sync::Lazy;
 use parking_lot::RwLock;
 use serde_json::json;
 use std::collections::HashMap;
+use std::fmt::Write as FmtWrite;
 use std::io::Write;
-
-use crate::{calc_next_update, error::Result, history, round_to_nearest_15, AUCTIONS, CONFIG, SOURCE, SPONSOR};
+use crate::{calc_next_update, error::Result, history, round_to_nearest_15, FilterPrice, FilterType, AUCTIONS, CONFIG, SOURCE, SPONSOR};
 
 // Standard JSON response for 404 Not Found errors
 static NOTFOUND: &[u8] = b"{\"error\": \"not found\"}";
@@ -77,25 +77,21 @@ async fn response(req: Request<Body>) -> Result<Response<Body>> {
     }
 
     let uri_path = req.uri().path();
+    let no_trailing = uri_path.strip_suffix('/').unwrap_or(uri_path);
     let query = req.uri().query().unwrap_or("");
 
     // Safely identify and strip the .gz suffix if present
-    let is_gzip = uri_path.ends_with(".gz");
-    let unzipped_path = if is_gzip {
-        uri_path.strip_suffix(".gz").unwrap_or(uri_path)
+    let is_gzip = no_trailing.ends_with(".gz") && !no_trailing.ends_with("/.gz");
+    let clean_path = if is_gzip {
+        no_trailing.strip_suffix(".gz").unwrap_or(no_trailing)
     } else {
-        uri_path
-    };
-
-    // Strip trailing slash (excluding the root path itself)
-    let clean_path = if unzipped_path != "/" {
-        unzipped_path.strip_suffix('/').unwrap_or(unzipped_path)
-    } else {
-        unzipped_path
+        no_trailing
     };
 
     // Split the route from the parameter to preserve case-sensitivity for item IDs
-    let (route_base, path_param) = if let Some(idx) = clean_path[1..].find('/') {
+    let (route_base, path_param) = if clean_path.is_empty() {
+        ("", None)
+    } else if let Some(idx) = clean_path[1..].find('/') {
         let split_idx = idx + 1;
         (&clean_path[..split_idx], Some(&clean_path[split_idx + 1..]))
     } else {
@@ -128,8 +124,8 @@ async fn response(req: Request<Body>) -> Result<Response<Body>> {
         "{}:{}:{}:{}:{}",
         route_str,
         path_param.unwrap_or(""),
-        q_type,
-        q_price,
+        q_type as u8,
+        q_price as u8,
         is_gzip
     );
 
@@ -140,6 +136,7 @@ async fn response(req: Request<Body>) -> Result<Response<Body>> {
         let base_param = param.strip_suffix(".json").unwrap_or(param);
         let days_str = base_param.strip_suffix("day").unwrap_or("");
 
+        #[allow(clippy::collapsible_if)]
         if let Ok(days) = days_str.parse::<usize>() {
             if (1..=history::DAY_SLOTS).contains(&days) {
                 return if let Some(bytes) = history::get_cache(days as u8) {
@@ -165,6 +162,7 @@ async fn response(req: Request<Body>) -> Result<Response<Body>> {
     }
 
     // Check pre-computed cache for heavy endpoints
+    #[allow(clippy::collapsible_if)]
     if route_str == "/lowestbins" || route_str == "/lowestbins.json" || route_str == "/lowestbins.txt" {
         if let Some(cached_data) = RESPONSE_CACHE.read().get(&cache_key) {
             if req.method() == Method::HEAD {
@@ -178,25 +176,21 @@ async fn response(req: Request<Body>) -> Result<Response<Body>> {
         return Ok(resp.body(Body::empty())?);
     }
 
-    let raw_bytes: Vec<u8> = match route_str {
-        "/lowestbins" | "/lowestbins.json" => {
+    let raw_bytes: Vec<u8> = match (route_str, path_param) {
+        ("/lowestbins" | "/lowestbins.json", None) => {
             let map = AUCTIONS.lock().build_combined_map(q_type, q_price);
             serde_json::to_vec(&map)?
         }
-        "/lowestbins.txt" => {
+        ("/lowestbins.txt", None) => {
             let auc = AUCTIONS.lock();
             // approximately 30 characters per line
             let mut res = String::with_capacity(auc.historical_auctions.len() * 30);
            auc.for_each_price(q_type, q_price, |key, value| {
-                res.push_str(key);
-                res.push(' ');
-                res.push_str(&value.to_string());
-                res.push('\n');
+               let _ = writeln!(res, "{} {}", key, value);
             });
             res.into_bytes()
         }
-        "/auction" | "/lowestbin" => {
-            let param = path_param.unwrap_or("");
+        ("/auction" | "/lowestbin", Some(param)) => {
             let id = param.strip_suffix(".json").unwrap_or(param);
 
             if let Some(price) = AUCTIONS.lock().get_price(id, q_type, q_price) {
@@ -205,20 +199,21 @@ async fn response(req: Request<Body>) -> Result<Response<Body>> {
                 return Ok(not_found());
             }
         }
-        "/metrics" => {
+        ("/metrics", None) => {
             let auc = AUCTIONS.lock();
             let mut res = String::with_capacity(auc.historical_auctions.len() * 90);
             res.push_str("# HELP price Price of each item\n# TYPE price gauge\n");
-            auc.for_each_price("all", "historical", |item, price| {
+            auc.for_each_price(FilterType::All, FilterPrice::Historical, |item, price| {
                 let display_name = to_display_name(item);
-                res.push_str(&format!(
-                    "lowestbin_price{{item=\"{}\", display=\"{}\"}} {}\n",
+                let _ = writeln!(
+                    res,
+                    "lowestbin_price{{item=\"{}\", display=\"{}\"}} {}",
                     item, display_name, price
-                ));
+                );
             });
             res.into_bytes()
         }
-        "/" | "" => {
+        ("/" | "", None) => {
             let mut endpoints = vec!["/lowestbins.json".to_owned(), "/lowestbins.txt".to_owned()];
             if CONFIG.enable_history {
                 for days in 1..=history::DAY_SLOTS {
@@ -270,20 +265,24 @@ fn not_found() -> Response<Body> {
 }
 
 // Helper for strict query parsing
-fn parse_query(query: &str) -> (&'static str, &'static str) {
-    let (mut t, mut p) = ("all", "historical");
+fn parse_query(query: &str) -> (FilterType, FilterPrice) {
+    let mut t = FilterType::All;
+    let mut p = FilterPrice::Historical;
+
     for param in query.split('&') {
-        match param.split_once('=') {
-            Some(("type", v)) => t = match v {
-                "auction" => "auction",
-                "bazaar" => "bazaar",
-                _ => "all"
-            },
-            Some(("price", v)) => p = match v {
-                "available" => "available",
-                _ => "historical"
-            },
-            _ => {}
+        if let Some((key, value)) = param.split_once('=') {
+            match key {
+                "type" => t = match value {
+                    "auction" => FilterType::Auction,
+                    "bazaar" => FilterType::Bazaar,
+                    _ => FilterType::All,
+                },
+                "price" => p = match value {
+                    "available" => FilterPrice::Available,
+                    _ => FilterPrice::Historical,
+                },
+                _ => {}
+            }
         }
     }
     (t, p)

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,14 +1,30 @@
+use flate2::write::GzEncoder;
+use flate2::Compression;
 use hyper::{
+    body::Bytes,
     header,
     http::response,
     service::{make_service_fn, service_fn},
     Body, Method, Request, Response, Server,
 };
+use once_cell::sync::Lazy;
+use parking_lot::RwLock;
 use serde_json::json;
+use std::collections::HashMap;
+use std::io::Write;
 
-use crate::{calc_next_update, error::Result, round_to_nearest_15, AUCTIONS, CONFIG, SOURCE, SPONSOR};
-// add a json not found response
+use crate::{calc_next_update, error::Result, history, round_to_nearest_15, AUCTIONS, CONFIG, SOURCE, SPONSOR};
+
+// Standard JSON response for 404 Not Found errors
 static NOTFOUND: &[u8] = b"{\"error\": \"not found\"}";
+
+// Global response cache for heavy, frequently accessed endpoints
+static RESPONSE_CACHE: Lazy<RwLock<HashMap<String, Bytes>>> = Lazy::new(|| RwLock::new(HashMap::new()));
+
+/// Clears the global response cache. Should be called after AUCTIONS map updates.
+pub fn clear_response_cache() {
+    RESPONSE_CACHE.write().clear();
+}
 
 pub async fn start_server() -> Result<()> {
     let addr = format!("{}:{}", CONFIG.host, CONFIG.port)
@@ -31,89 +47,247 @@ pub async fn start_server() -> Result<()> {
 fn response_base() -> response::Builder {
     let update = round_to_nearest_15(calc_next_update());
     Response::builder()
-        .header(header::CONTENT_TYPE, "application/json")
         .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
-        .header(header::ACCESS_CONTROL_ALLOW_METHODS, "GET, OPTIONS")
+        .header(header::ACCESS_CONTROL_ALLOW_METHODS, "GET, HEAD, OPTIONS")
         .header(header::ACCESS_CONTROL_ALLOW_HEADERS, "*")
         .header(header::CACHE_CONTROL, format!("max-age={update}, s-maxage={update}"))
         .header(header::ACCESS_CONTROL_MAX_AGE, "86400")
         .header("funding", SPONSOR)
 }
 
+/// Compresses a byte slice using standard Gzip (DEFLATE) algorithm
+fn gzip_bytes(data: &[u8]) -> Result<Bytes> {
+    let mut encoder = GzEncoder::new(
+        Vec::with_capacity(data.len() / 3),
+        Compression::default()
+    );
+    encoder.write_all(data)?;
+    Ok(Bytes::from(encoder.finish()?))
+}
+
 async fn response(req: Request<Body>) -> Result<Response<Body>> {
-    let path = req.uri().path().trim_end_matches('/');
+    // Handle CORS Preflight (OPTIONS)
+    if req.method() == Method::OPTIONS {
+        return Ok(response_base().status(204).body(Body::empty())?);
+    }
+    // Only permit GET and HEAD requests for data
+    let is_head = req.method() == Method::HEAD;
+    if !is_head && req.method() != Method::GET {
+        return Ok(response_base().status(405).body(Body::empty())?);
+    }
 
-    match (req.method(), path) {
-        (&Method::GET, "/lowestbins.json") | (&Method::GET, "/lowestbins") | (&Method::GET, "/auctions/lowestbins") => {
-            let bytes = serde_json::to_vec(&*AUCTIONS.lock())?;
-            Ok(response_base().body(Body::from(bytes))?)
-        }
-        (&Method::GET, "/lowestbins.txt") => {
-            let mut res = String::new();
-            for (key, value) in &*AUCTIONS.lock() {
-                res.push_str(&format!("{key} {value}\n"));
-            }
-            Ok(response_base()
-                .header(header::CONTENT_TYPE, "text/plain")
-                .body(Body::from(res))?)
-        }
-        (&Method::GET, route) if route.starts_with("/auction/") || route.starts_with("/lowestbin/") => {
-            let id = route.trim_start_matches("/auction/").trim_start_matches("/lowestbin/");
-            let auctions = AUCTIONS.lock();
-            let value = auctions.get(id);
+    let uri_path = req.uri().path();
+    let query = req.uri().query().unwrap_or("");
 
-            if let Some(auction) = value {
-                let bytes = serde_json::to_vec(&auction)?;
-                Ok(response_base().body(Body::from(bytes))?)
-            } else {
-                Ok(not_found())
-            }
-        }
-        (&Method::GET, "/metrics") => {
-            let mut res = "# HELP price Price of each item\n# TYPE price gauge".to_owned();
-            for (item, price) in &*AUCTIONS.lock() {
-                let display_name = to_display_name(item);
-                res.push_str(&format!(
-                    "\nlowestbin_price{{item=\"{item}\", display=\"{display_name}\"}} {price}",
-                ));
-            }
+    // Safely identify and strip the .gz suffix if present
+    let is_gzip = uri_path.ends_with(".gz");
+    let unzipped_path = if is_gzip {
+        uri_path.strip_suffix(".gz").unwrap_or(uri_path)
+    } else {
+        uri_path
+    };
 
-            Ok(response_base().body(Body::from(res)).unwrap())
-        }
-        (&Method::GET, route) if route.starts_with("/averages/") && CONFIG.enable_history => {
-            let days_str = route.trim_start_matches("/averages/").trim_end_matches("day");
+    // Strip trailing slash (excluding the root path itself)
+    let clean_path = if unzipped_path != "/" {
+        unzipped_path.strip_suffix('/').unwrap_or(unzipped_path)
+    } else {
+        unzipped_path
+    };
 
-            if let Ok(days) = days_str.parse::<u8>()
-                && (1..=7).contains(&days)
-                    && let Some(bytes) = crate::history::get_cache(days) {
-                        return Ok(response_base().body(Body::from(bytes))?);
+    // Split the route from the parameter to preserve case-sensitivity for item IDs
+    let (route_base, path_param) = if let Some(idx) = clean_path[1..].find('/') {
+        let split_idx = idx + 1;
+        (&clean_path[..split_idx], Some(&clean_path[split_idx + 1..]))
+    } else {
+        (clean_path, None)
+    };
+
+    // Normalize only the route segment for secure and consistent matching
+    let normalized_route = route_base.to_ascii_lowercase();
+    let route_str = if normalized_route.is_empty() {
+        ""
+    } else {
+        normalized_route.as_str()
+    };
+
+    let content_type = if is_gzip {
+        "application/gzip"
+    } else {
+        match route_str {
+            "/lowestbins.txt" => "text/plain",
+            "/metrics" => "text/plain; version=0.0.4",
+            _ => "application/json",
+        }
+    };
+    let mut resp = response_base().header(header::CONTENT_TYPE, content_type);
+
+    let (q_type, q_price) = parse_query(query);
+
+    // Construct a canonical cache key incorporating all variables to prevent cache collisions
+    let cache_key = format!(
+        "{}:{}:{}:{}:{}",
+        route_str,
+        path_param.unwrap_or(""),
+        q_type,
+        q_price,
+        is_gzip
+    );
+
+    // Bypass RESPONSE_CACHE for averages (already cached in history.rs)
+    if route_str == "/averages" && CONFIG.enable_history {
+        let param = path_param.unwrap_or("");
+        // Safely strip optional .json suffix, then extract the day integer
+        let base_param = param.strip_suffix(".json").unwrap_or(param);
+        let days_str = base_param.strip_suffix("day").unwrap_or("");
+
+        if let Ok(days) = days_str.parse::<usize>() {
+            if (1..=history::DAY_SLOTS).contains(&days) {
+                return if let Some(bytes) = history::get_cache(days as u8) {
+                    if req.method() == Method::HEAD {
+                        return Ok(resp.body(Body::empty())?);
                     }
-            Ok(not_found())
-        }
-        (_, "") => {
-            let mut endpoints = vec!["/lowestbins".to_owned(), "/lowestbins.txt".to_owned()];
-            if CONFIG.enable_history {
-                for days in 1..=7 {
-                    endpoints.push(format!("/averages/{}day", days));
+
+                    let final_data = if is_gzip {
+                        gzip_bytes(&bytes)?
+                    } else {
+                        bytes.clone()
+                    };
+                    Ok(resp.body(Body::from(final_data))?)
+                } else {
+                    Ok(response_base()
+                        .header(header::CONTENT_TYPE, "application/json")
+                        .status(503)
+                        .body(Body::from(r#"{"error": "History cache is currently building. Please try again in a moment."}"#))?)
                 }
             }
-            Ok(response_base()
-                .header(header::CACHE_CONTROL, "max-age=2, s-maxage=2")
-                .body(Body::from(serde_json::to_vec_pretty(&json!({
-                    "message": "Welcome to the lowestbins API",
-                    "endpoints": endpoints,
-                    "updates_in": calc_next_update(),
-                    "funding": SPONSOR,
-                    "source": SOURCE
-                }))?))?)
         }
-        _ => Ok(not_found()),
+        return Ok(not_found());
     }
+
+    // Check pre-computed cache for heavy endpoints
+    if route_str == "/lowestbins" || route_str == "/lowestbins.json" || route_str == "/lowestbins.txt" {
+        if let Some(cached_data) = RESPONSE_CACHE.read().get(&cache_key) {
+            if req.method() == Method::HEAD {
+                return Ok(resp.body(Body::empty())?);
+            }
+            return Ok(resp.body(Body::from(cached_data.clone()))?);
+        }
+    }
+
+    if is_head {
+        return Ok(resp.body(Body::empty())?);
+    }
+
+    let raw_bytes: Vec<u8> = match route_str {
+        "/lowestbins" | "/lowestbins.json" => {
+            let map = AUCTIONS.lock().build_combined_map(q_type, q_price);
+            serde_json::to_vec(&map)?
+        }
+        "/lowestbins.txt" => {
+            let auc = AUCTIONS.lock();
+            // approximately 30 characters per line
+            let mut res = String::with_capacity(auc.historical_auctions.len() * 30);
+           auc.for_each_price(q_type, q_price, |key, value| {
+                res.push_str(key);
+                res.push(' ');
+                res.push_str(&value.to_string());
+                res.push('\n');
+            });
+            res.into_bytes()
+        }
+        "/auction" | "/lowestbin" => {
+            let param = path_param.unwrap_or("");
+            let id = param.strip_suffix(".json").unwrap_or(param);
+
+            if let Some(price) = AUCTIONS.lock().get_price(id, q_type, q_price) {
+                serde_json::to_vec(&price)?
+            } else {
+                return Ok(not_found());
+            }
+        }
+        "/metrics" => {
+            let auc = AUCTIONS.lock();
+            let mut res = String::with_capacity(auc.historical_auctions.len() * 90);
+            res.push_str("# HELP price Price of each item\n# TYPE price gauge\n");
+            auc.for_each_price("all", "historical", |item, price| {
+                let display_name = to_display_name(item);
+                res.push_str(&format!(
+                    "lowestbin_price{{item=\"{}\", display=\"{}\"}} {}\n",
+                    item, display_name, price
+                ));
+            });
+            res.into_bytes()
+        }
+        "/" | "" => {
+            let mut endpoints = vec!["/lowestbins.json".to_owned(), "/lowestbins.txt".to_owned()];
+            if CONFIG.enable_history {
+                for days in 1..=history::DAY_SLOTS {
+                    endpoints.push(format!("/averages/{}day.json", days));
+                }
+            }
+            let bytes = serde_json::to_vec_pretty(&json!({
+                "message": "Welcome to the lowestbins API",
+                "endpoints": endpoints,
+                "parameters": {
+                    "type": "Filters items by source. Options: 'all' (default), 'auction', 'bazaar'",
+                    "price": "Filters auction items by state. Options: 'historical' (default, last known price), 'available' (currently active on ah)"
+                },
+                "updates_in": calc_next_update(),
+                "funding": SPONSOR,
+                "source": SOURCE
+            }))?;
+
+            resp = resp.header(header::CACHE_CONTROL, "max-age=2, s-maxage=2");
+            bytes
+        }
+        _ => {
+            return Ok(not_found());
+        }
+    };
+
+    // Apply compression
+    let final_data = if is_gzip {
+        gzip_bytes(&raw_bytes)?
+    } else {
+        Bytes::from(raw_bytes)
+    };
+
+    // Save only heavy endpoints to cache
+    if route_str == "/lowestbins" || route_str == "/lowestbins.json" || route_str == "/lowestbins.txt" {
+        RESPONSE_CACHE.write().insert(cache_key, final_data.clone());
+    }
+
+    Ok(resp.body(Body::from(final_data))?)
 }
 
 /// HTTP status code 404
 fn not_found() -> Response<Body> {
-    response_base().status(404).body(NOTFOUND.into()).unwrap()
+    response_base()
+        .status(404)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(NOTFOUND.into())
+        .unwrap()
+}
+
+// Helper for strict query parsing
+fn parse_query(query: &str) -> (&'static str, &'static str) {
+    let (mut t, mut p) = ("all", "historical");
+    for param in query.split('&') {
+        let mut parts = param.splitn(2, '=');
+        match (parts.next(), parts.next()) {
+            (Some("type"), Some(v)) => t = match v {
+                "auction" => "auction",
+                "bazaar" => "bazaar",
+                _ => "all"
+            },
+            (Some("price"), Some(v)) => p = match v {
+                "available" => "available",
+                _ => "historical"
+            },
+            _ => {}
+        }
+    }
+    (t, p)
 }
 
 include!("../generated/to_display_name.rs");


### PR DESCRIPTION
- Refactor `AUCTIONS` into `PriceState` to separate historical, available, and bazaar price data.
- Switch bazaar price source from `quick_status` to lowest `price_per_unit` from `buy_summary`.
- Migrate history pipeline and storage to `f64` for bazaar price precision.
- Add Gzip compression support via `.gz` URL suffix with proper MIME headers.
- Implement `RESPONSE_CACHE` with RwLock and normalized cache keys to prevent casing-based fragmentation.
- Replace per-request map clones with `for_each_price` iterator for metrics and text endpoints.
- Preserve original item ID casing in path parameters while normalizing route segments for matching.
- Exclude zero or invalid price items from history snapshots to maintain average integrity.
- Remove deprecated `/auctions/lowestbins` endpoint alias in favor of standardized routes.